### PR TITLE
Add tests for s2i run

### DIFF
--- a/ansible/tests.sh
+++ b/ansible/tests.sh
@@ -1,3 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" --version

--- a/arc42-tools/tests.sh
+++ b/arc42-tools/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" plantuml -v
 docker run --rm "${DOCKER_IMAGE}:${TAG}" asciidoctor -v

--- a/awscli/tests.sh
+++ b/awscli/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" help

--- a/ci-build/tests.sh
+++ b/ci-build/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" bash --version
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" docker --version

--- a/ci-clair/tests.sh
+++ b/ci-clair/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" test -f /clair
 docker run --rm "${DOCKER_IMAGE}:${TAG}" test -f /config/config.yaml
 docker run --rm "${DOCKER_IMAGE}:${TAG}" clair-scanner -h

--- a/ci-helm/2.10/tests.sh
+++ b/ci-helm/2.10/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" docker --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" git --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" ansible --version

--- a/ci-helm/2.11/tests.sh
+++ b/ci-helm/2.11/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" docker --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" git --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" ansible --version

--- a/ci-helm/2.12/tests.sh
+++ b/ci-helm/2.12/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" docker --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" git --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" helm version -c

--- a/ci-helm/2.13/tests.sh
+++ b/ci-helm/2.13/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" docker --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" git --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" helm version -c

--- a/java/alpine/11/tests.sh
+++ b/java/alpine/11/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" java --version
 

--- a/java/alpine/8/tests.sh
+++ b/java/alpine/8/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" java -version
 

--- a/java/centos/11/tests.sh
+++ b/java/centos/11/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" java --version
 

--- a/java/centos/8/tests.sh
+++ b/java/centos/8/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" java -version
 

--- a/nginx/alpine/tests.sh
+++ b/nginx/alpine/tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" nginx -t
 docker run -eNGINX_DISABLE_ACCESS_LOG=true --rm "${DOCKER_IMAGE}:${TAG}" nginx -t
 

--- a/nginx/centos/Dockerfile
+++ b/nginx/centos/Dockerfile
@@ -18,15 +18,10 @@ RUN yum update -y && yum clean all && rm -rf /var/cache/yum \
     && ln -sf /opt/rh/rh-nginx${NGINX_SHORT_VER}/root/usr/share/nginx/html/50x.html /opt/app-root/src/50x.html
 
 # Required if nginx is updated via yum
-# https://github.com/sclorg/nginx-container/blob/master/1.14/Dockerfile#L59
+# should be the same like
+# https://github.com/sclorg/nginx-container/blob/master/1.14/Dockerfile#L60
+# expect the sed line
 RUN chmod a+rwx ${NGINX_CONF_PATH} && \
-    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.d/ && \
-    mkdir -p ${NGINX_APP_ROOT}/etc/nginx.default.d/ && \
-    mkdir -p ${NGINX_APP_ROOT}/src/nginx-start/ && \
-    mkdir -p ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \
-    mkdir -p /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx && \
-    ln -sf /dev/stdout /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/opt/rh/rh-nginx${NGINX_SHORT_VER}/log/nginx/error.log && \
     chmod -R a+rwx ${NGINX_APP_ROOT}/etc && \
     chmod -R a+rwx /var/opt/rh/rh-nginx${NGINX_SHORT_VER} && \
     chmod -R a+rwx ${NGINX_CONTAINER_SCRIPTS_PATH}/nginx-start && \

--- a/nginx/centos/tests.sh
+++ b/nginx/centos/tests.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
+set -euo pipefail
+
 docker run --rm "${DOCKER_IMAGE}:${TAG}" nginx -t
 
 # Test as Openshift UID
 docker run --rm -u 1000090000:0 "${DOCKER_IMAGE}:${TAG}" whoami
 docker run --rm -u 1000090000:0 "${DOCKER_IMAGE}:${TAG}" nginx -t
+
+# Test SCL entrypoint
+
+docker run --name nginx-scl-test -d --rm -u 1000090000:0 "${DOCKER_IMAGE}:${TAG}" /usr/libexec/s2i/run
+docker exec nginx-scl-test curl -I -sSf http://localhost:8080/404.html
+docker logs nginx-scl-test
+docker rm -f nginx-scl-test

--- a/node/alpine/10/tests.sh
+++ b/node/alpine/10/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" node --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" npm --version

--- a/node/alpine/8/tests.sh
+++ b/node/alpine/8/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" node --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" npm --version

--- a/node/centos/10/tests.sh
+++ b/node/centos/10/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" node --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" npm --version

--- a/node/centos/8/tests.sh
+++ b/node/centos/8/tests.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+set -euo pipefail
 
 docker run --rm "${DOCKER_IMAGE}:${TAG}" node --version
 docker run --rm "${DOCKER_IMAGE}:${TAG}" npm --version


### PR DESCRIPTION
make the centos scl image more robust.

Add tests to prevent errors and failures in downstream images.